### PR TITLE
Changed Composition Header to derive from ClinicalDocument FHIR IG

### DIFF
--- a/FHIR-us-pacio-adi.xml
+++ b/FHIR-us-pacio-adi.xml
@@ -25,8 +25,8 @@
 <artifact deprecated="true" id="StructureDefinition/PADI-Goal" key="StructureDefinition-PADI-Goal" name="ADI Goal"/>
 <artifact id="CodeSystem/ADIPreferenceCategoryCS" key="CodeSystem-PADIGoalCategoryCS" name="ADI Goal Category Code System"/>
 <artifact id="StructureDefinition/ADI-HealthcareAgentConsent" key="StructureDefinition-ADI-HealthcareAgentConsent" name="ADI Healthcare Agent Consent"/>
-<artifact id="StructureDefinition/ADI-ADIConsentDeny" key="StructureDefinition-ADI-ADIConsentDeny" name="ADI Healthcare Agent Consent Deny"/>
-<artifact id="StructureDefinition/ADI-ADIConsentPermit" key="StructureDefinition-ADI-ADIConsentPermit" name="ADI Healthcare Agent Consent Permit"/>
+<artifact id="StructureDefinition/ADI-HealthcareAgentConsentDeny" key="StructureDefinition-ADI-ADIConsentDeny" name="ADI Healthcare Agent Consent Deny"/>
+<artifact id="StructureDefinition/ADI-HealthcareAgentConsentPermit" key="StructureDefinition-ADI-ADIConsentPermit" name="ADI Healthcare Agent Consent Permit"/>
 <artifact id="StructureDefinition/ADI-HealthcareAgentParticipant" key="StructureDefinition-ADI-HealthcareAgentParticipant" name="ADI Healthcare Agent Participant"/>
 <artifact id="StructureDefinition/ADI-Jurisdiction" key="StructureDefinition-ADI-Jurisdiction" name="ADI Jurisdiction"/>
 <artifact deprecated="true" id="StructureDefinition/ADI-ADIMinimalSourceFormInformation" key="StructureDefinition-ADI-ADIMinimalSourceFormInformation" name="ADI Minimal Source Form"/>

--- a/input/fsh/ADICompositionHeaderProfile.fsh
+++ b/input/fsh/ADICompositionHeaderProfile.fsh
@@ -1,5 +1,5 @@
 Profile: ADICompositionHeader
-Parent: clinicaldocument
+Parent: $ClinicalDocumentComposition
 Id: ADI-Composition-Header
 Title: "ADI Composition Header"
 Description: "This abstract profile defines constraints that represent common administrative and demographic concepts for advance directives information used in US Realm clinical documents."
@@ -28,7 +28,6 @@ Description: "This abstract profile defines constraints that represent common ad
 * type MS
 * type from $VSACADIDocumentTypesGrouper (extensible) // fix for FHIR-55633 tying .category and .type to VSAC value sets
 
-* category 0..1 MS
 // * category = $LOINC#42348-3 "Advance healthcare directives"
 * category from $VSACADIAdvanceDirectiveCategories (extensible) // fix for FHIR-55633 tying .category and .type to VSAC value sets
 

--- a/input/fsh/ADIHealthcareAgentConsentProfile.fsh
+++ b/input/fsh/ADIHealthcareAgentConsentProfile.fsh
@@ -61,17 +61,17 @@ The authorized personal representative appointed as healthcare agents are refere
 * provision.purpose from http://terminology.hl7.org/ValueSet/v3-ActReason (required)
 
 
-Profile: ADIConsentPermit
+Profile: ADIHealthcareAgentConsentPermit
 Parent: ADIHealthcareAgentConsent
-Id: ADI-ADIConsentPermit
+Id: ADI-HealthcareAgentConsentPermit
 Title: "ADI Healthcare Agent Consent Permit"
 Description: "This profile is used to represent permit consents for an advance directive participant such as a healthcare agent or advisor and power or limitation granted to such persons."
 
 * provision.type = #permit
 
-Profile: ADIConsentDeny
+Profile: ADIHealthcareAgentConsentDeny
 Parent: ADIHealthcareAgentConsent
-Id: ADI-ADIConsentDeny
+Id: ADI-HealthcareAgentConsentDeny
 Title: "ADI Healthcare Agent Consent Deny"
 Description: "The ADI Healthcare Agent Consent Deny profile is used to constrain the powers permitted for the healthcare agent appointment through the ADI Healthcare Agent Consent Permit profile."
 

--- a/input/fsh/AL_Aliases.fsh
+++ b/input/fsh/AL_Aliases.fsh
@@ -98,3 +98,6 @@ Alias: $HL7v3DocumentFormatCodes = http://terminology.hl7.org/CodeSystem/v3-HL7D
 
 // Aliases for local value sets
 Alias: $ADIPractitionerRoleVS = http://hl7.org/fhir/us/pacio-adi/ValueSet/ADIPractitionerRoleVS
+
+// Alias for Clinical Documents IG
+Alias: $ClinicalDocumentComposition = http://hl7.org/fhir/uv/fhir-clinical-document/StructureDefinition/clinical-document-composition 

--- a/input/fsh/Example_MHAD_BetsySmith-Johnson.fsh
+++ b/input/fsh/Example_MHAD_BetsySmith-Johnson.fsh
@@ -133,7 +133,7 @@ Usage: #example
 // ******************
 
 Instance: Example-Smith-Johnson-HealthcareAgentConsent2
-InstanceOf: ADIConsentPermit
+InstanceOf: ADIHealthcareAgentConsentPermit
 Description: "Example Patient Smith-Johnson Healthcare Agent Consent"
 Usage: #example
 * text.status = #additional

--- a/input/fsh/Example_PACP_BetsySmith-Johnson.fsh
+++ b/input/fsh/Example_PACP_BetsySmith-Johnson.fsh
@@ -473,7 +473,7 @@ Usage: #example
 
 // TODO update text
 Instance: Example-Smith-Johnson-HealthcareAgentConsent
-InstanceOf: ADIConsentPermit
+InstanceOf: ADIHealthcareAgentConsentPermit
 Description: "Example Patient Smith-Johnson Healthcare Agent Consent"
 Usage: #example
 * text.status = #additional

--- a/input/fsh/Example_PMO_BetsySmith-Johnson.fsh
+++ b/input/fsh/Example_PMO_BetsySmith-Johnson.fsh
@@ -208,7 +208,7 @@ Usage: #example
 * orderDetail = $LOINC#LA33470-8
 
 Instance: Example-Smith-Johnson-HealthcareAgentConsent-Permit
-InstanceOf: ADIConsentPermit
+InstanceOf: ADIHealthcareAgentConsentPermit
 Description: "Example of ADI Healthcare Agent Permit"
 Usage: #example
 
@@ -223,7 +223,7 @@ Usage: #example
 * provision.actor.reference = Reference(RelatedPerson/Example-Smith-Johnson-HealthcareAgent1)
 
 Instance: Example-Smith-Johnson-HealthcareAgentConsent-Deny
-InstanceOf: ADIConsentDeny
+InstanceOf: ADIHealthcareAgentConsentDeny
 Description: "Example of ADI Healthcare Agent Deny"
 Usage: #example
 

--- a/input/pagecontent/artifact_resource_type.md
+++ b/input/pagecontent/artifact_resource_type.md
@@ -1,3 +1,6 @@
+### Binary
+* [ADI Source Form](StructureDefinition-ADI-ADISourceFormInformation.html)
+
 ### Bundle
 * [ADI Bundle](StructureDefinition-ADI-Bundle.html)
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,4 +1,17 @@
-The Advance Healthcare Directive Interoperability (ADI) FHIR implementation guide (IG) explains how to represent, exchange, and verify a person’s goals, preferences and priorities for medical treatment and interventions regarding future medical care. It also explains how to represent a person’s appointment of one or more healthcare agents who can make care decisions for the patient if the patient can’t communicate. 
+<div style="width: 60%;" >
+<h3 id="plain-language-summary-about-this-guide"><a class="anchorjs-link " href="#plain-language-summary-about-this-guide" aria-label="Anchor" data-anchorjs-icon="" style="font: 1em / 1 anchorjs-icons; padding-left: 0.375em;"></a>
+  <button class="btn btn-info btn-lg collapsed" type="button" title="Click to Open or Close the Plain Language Summary" data-toggle="collapse" data-target="#plain-lang-summary" aria-expanded="false" aria-controls="collapseExample">
+    Click Here to see the Plain Language Summary
+  </button>
+</h3>
+</div>
+<div class="collapse" id="plain-lang-summary" aria-expanded="false" style="height: 0px;">
+  <div class="card card-body" style="border:1px solid;border-color:#cccccc;padding:10px">
+
+<p>The Advance Healthcare Directive Interoperability (ADI) FHIR implementation guide (IG) explains how to represent, exchange, and verify a person’s goals, preferences and priorities for medical treatment and interventions regarding future medical care. It also explains how to represent a person’s appointment of one or more healthcare agents who can make care decisions for the patient if the patient can’t communicate.</p>
+
+  </div>
+</div> 
 
 <blockquote class="stu-note">
     <p>


### PR DESCRIPTION
- ADICompositionHeader now derives from http://hl7.org/fhir/uv/fhir-clinical-document/StructureDefinition/clinical-document-composition